### PR TITLE
for multiple cases, not only marker shape, but also color, are different

### DIFF
--- a/skill_metrics/plot_pattern_diagram_markers.py
+++ b/skill_metrics/plot_pattern_diagram_markers.py
@@ -54,8 +54,8 @@ def plot_pattern_diagram_markers(X,Y,option):
         
         # Define markers
         kind = ['+','o','x','s','d','^','v','p','h','*']
-        colorm = ['b','r','g','c','m','y','k']
-        if len(X) > 70:
+        colorm = ['r','b','g','c','m','y','k','gray']
+        if len(X) > 80:
             _disp('You must introduce new markers to plot more than 70 cases.')
             _disp('The ''marker'' character array need to be extended inside the code.')
         
@@ -64,10 +64,14 @@ def plot_pattern_diagram_markers(X,Y,option):
             marker = []
             markercolor = []
             for color in colorm:
+                if option['markercolor'] == 'r':
+                    rgba = clr.to_rgb(color) + (alpha,)
+                else:
+                    rgba = clr.to_rgb(option['markercolor']) + (alpha,)
+                markercolor.append(rgba)
                 for symbol in kind:
                     marker.append(symbol + option['markercolor'])
-                    rgba = clr.to_rgb(option['markercolor']) + (alpha,)
-                    markercolor.append(rgba)
+                    #rgba = clr.to_rgb(option['markercolor']) + (alpha,)
         else:
             # Define markers and colors using predefined list
             marker = []
@@ -86,7 +90,7 @@ def plot_pattern_diagram_markers(X,Y,option):
             if abs(X[i]) <= limit and abs(Y[i]) <= limit:
                 h = plt.plot(X[i],Y[i],marker[i], markersize = markerSize, 
                      markerfacecolor = markercolor[i],
-                     markeredgecolor = marker[i][1],
+                     markeredgecolor = markercolor[i],
                      markeredgewidth = 2)
                 hp += tuple(h)
                 markerlabel.append(option['markerlabel'][i])


### PR DESCRIPTION
I wanted to plot multiple cases on the Taylor Diagram, but I needed the markers to be not only different shapes, but also different colors.

So, I basically made 4 changes:
1. Added one more color, gray, to the default colors and accordingly increased the max case size to 80.
2. Switched the blue and red colors in the default color array, colorm, so that if a color other than red is sent with the markercolor option, then it will be used.
3. If the number of cases is <= the default number of markers, then each case gets a different marker shape and color (instead of only the default color of red or the one color that can be passed in with the markercolor option).
4. Made the marker edge color match the color of the marker

I've included here the result from the taylor5.py example.

![taylor5_example](https://user-images.githubusercontent.com/6895400/116615759-c03daf80-a909-11eb-974f-d2b2d4cb1558.png)
 