### PR TITLE
Improved get_taylor_diagram_options file

### DIFF
--- a/Examples/taylor10.py
+++ b/Examples/taylor10.py
@@ -1,154 +1,150 @@
-'''
-How to create a Taylor diagram with a large number of symbols of
-different color along with a legend.
-
-A tenth example of how to create a Taylor diagram given one set of
-reference observations and multiple model predictions for the quantity.
-
-Produces a Taylor diagram showing how data available from public sources 
-can be used to populate an acceptable model of water temperatures in the 
-Farmington River basin of Connecticut.
-
-It supports the following arguments as options. 
-
--noshow : No figure is shown if this flag is present
--nosave : No figure is saved if this flag is present
-
-They can be invoked from a command line as, for example, to not show the
-plot to allow batch execution: 
-
-$ python taylor10.py -nosave
-
-The data are stored in arrays named: sdev, crmsd, ccoef, and gageID. Each of 
-these contain 1 reference value (first position) and 22 prediction values, 
-for a total of 23 values. These arrays are stored in a container which is 
-then written to a pickle file. A different file suffix is used depending upon 
-whether the file is created using Python 2 (.pkl) or Python 3 (.pkl3) because 
-the pickle package is not cross version compatible for pickle files containing 
-containers of dictionaries.
-
-The source data is an observation set at each location as well as a 
-simulation set. The reference value is chosen that more or less represents 
-the consensus on acceptable values of the root-mean square error.
-
-This data was provide courtesy of John Yearsley, Affiliate Professor,
-UW-Hydro|Computational Hydrology, University of Washington (Yearsley et al., 
-2019).
-
-References:
-
-Yearsley, J. R., Sun, N., Baptiste, M., and Nijssen, B. (2019) Assessing the 
-  Impacts of Hydrologic and Land Use Alterations on Water Temperature in the 
-  Farmington River Basin in Connecticut, Hydrol. Earth Syst. Sci. Discuss., 
-  https://doi.org/10.5194/hess-2019-94, 
-  https://www.hydrol-earth-syst-sci-discuss.net/hess-2019-94/hess-2019-94.pdf
-
-Authors: Peter A. Rochford
-         Andre D. L. Zanchetta
-
-Created on Dec 5, 2019
-Revised on Aug 28, 2022
-
-@author: rochford.peter1@gmail.com
-@author: adlzanchetta@gmail.com
-'''
-
-import argparse
-import matplotlib.pyplot as plt
-import numpy as np
-import pickle
-import skill_metrics as sm
-from sys import version_info
-
-def load_obj(name):
-    # Load object from file in pickle format
-    if version_info[0] == 2:
-        suffix = 'pkl'
-    else:
-        suffix = 'pkl3'
-
-    with open(name + '.' + suffix, 'rb') as f:
-        return pickle.load(f) # Python2 succeeds
-
-class Container(object): 
+'''
+How to create a Taylor diagram with a large number of symbols of
+different color along with a legend.
+
+A tenth example of how to create a Taylor diagram given one set of
+reference observations and multiple model predictions for the quantity.
+
+Produces a Taylor diagram showing how data available from public sources 
+can be used to populate an acceptable model of water temperatures in the 
+Farmington River basin of Connecticut.
+
+It supports the following arguments as options. 
+
+-noshow : No figure is shown if this flag is present
+-nosave : No figure is saved if this flag is present
+
+They can be invoked from a command line as, for example, to not show the
+plot to allow batch execution: 
+
+$ python taylor10.py -nosave
+
+The data are stored in arrays named: sdev, crmsd, ccoef, and gageID. Each of 
+these contain 1 reference value (first position) and 22 prediction values, 
+for a total of 23 values. These arrays are stored in a container which is 
+then written to a pickle file. A different file suffix is used depending upon 
+whether the file is created using Python 2 (.pkl) or Python 3 (.pkl3) because 
+the pickle package is not cross version compatible for pickle files containing 
+containers of dictionaries.
+
+The source data is an observation set at each location as well as a 
+simulation set. The reference value is chosen that more or less represents 
+the consensus on acceptable values of the root-mean square error.
+
+This data was provide courtesy of John Yearsley, Affiliate Professor,
+UW-Hydro|Computational Hydrology, University of Washington (Yearsley et al., 
+2019).
+
+References:
+
+Yearsley, J. R., Sun, N., Baptiste, M., and Nijssen, B. (2019) Assessing the 
+  Impacts of Hydrologic and Land Use Alterations on Water Temperature in the 
+  Farmington River Basin in Connecticut, Hydrol. Earth Syst. Sci. Discuss., 
+  https://doi.org/10.5194/hess-2019-94, 
+  https://www.hydrol-earth-syst-sci-discuss.net/hess-2019-94/hess-2019-94.pdf
+
+Authors: Peter A. Rochford
+         Andre D. L. Zanchetta
+
+Created on Dec 5, 2019
+Revised on Aug 28, 2022
+
+@author: rochford.peter1@gmail.com
+@author: adlzanchetta@gmail.com
+'''
+
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+import pickle
+import skill_metrics as sm
+from sys import version_info
+
+def load_obj(name):
+    # Load object from file in pickle format
+    if version_info[0] == 2:
+        suffix = 'pkl'
+    else:
+        suffix = 'pkl3'
+
+    with open(name + '.' + suffix, 'rb') as f:
+        return pickle.load(f) # Python2 succeeds
+
+class Container(object): 
+    
+    def __init__(self, pred1, pred2, pred3, ref):
+        self.pred1 = pred1
+        self.pred2 = pred2
+        self.pred3 = pred3
+        self.ref = ref
+        
+if __name__ == '__main__':
+
+    # Define optional arguments for script
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('-noshow', dest='no_show', action='store_true',
+                            help="No figure is shown if this flag is present.")
+    arg_parser.add_argument('-nosave', dest='no_save', action='store_true',
+                            help="No figure is saved if this flag is present.")
+    args = arg_parser.parse_args()
+    del arg_parser
+    
+    # Close any previously open graphics windows
+    # ToDo: fails to work within Eclipse
+    plt.close('all')
+        
+    # Read data from pickle file
+    data = load_obj('Farmington_River_data')
+    
+    # Change number of data points to illustrate effect
+    # of changing number of columns
+    ncol = 2
+    if ncol == 1:
+        sdev = data.sdev[0:11]
+        crmsd = data.crmsd[0:11]
+        ccoef = data.ccoef[0:11]
+        gageID = data.gageID[0:11]
+    elif ncol == 2:
+        sdev = data.sdev
+        crmsd = data.crmsd
+        ccoef = data.ccoef
+        gageID = data.gageID
+    else:
+        sdev = data.sdev
+        crmsd = data.crmsd
+        ccoef = data.ccoef
+        gageID = data.gageID
+        sdev = np.append(sdev,data.sdev[1:11])
+        crmsd = np.append(crmsd,data.crmsd[1:11])
+        ccoef = np.append(ccoef,data.ccoef[1:11])
+        gageID = gageID + data.gageID[1:11]
+    
+    # Specify labels for points in a cell array using gage ID.
+    label = gageID
+    
+    # Must set figure size here to prevent legend from being cut off
+    plt.figure(num=1, figsize=(8, 6))
+
+    
+    '''
+    Produce the Taylor diagram
+
+    Label the points and change the axis options for SDEV, CRMSD, and CCOEF.
+    Increase the upper limit for the SDEV axis and rotate the CRMSD contour 
+    labels (counter-clockwise from x-axis). Exchange color and line style
+    choices for SDEV, CRMSD, and CCOEFF variables to show effect. Increase
+    the line width of all lines. Suppress axes titles and add a legend.
+
+    For an exhaustive list of options to customize your diagram, 
+    please call the function at a Python command line:
+    >> taylor_diagram
+    '''
     
-    def __init__(self, pred1, pred2, pred3, ref):
-        self.pred1 = pred1
-        self.pred2 = pred2
-        self.pred3 = pred3
-        self.ref = ref
-        
-if __name__ == '__main__':
-
-    # Define optional arguments for script
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('-noshow', dest='no_show', action='store_true',
-                            help="No figure is shown if this flag is present.")
-    arg_parser.add_argument('-nosave', dest='no_save', action='store_true',
-                            help="No figure is saved if this flag is present.")
-    args = arg_parser.parse_args()
-    del arg_parser
+    sm.taylor_diagram(sdev,crmsd,ccoef, markerLabel = label,                    taylor_options_file='taylor_option_config.csv')
     
-    # Close any previously open graphics windows
-    # ToDo: fails to work within Eclipse
-    plt.close('all')
-        
-    # Read data from pickle file
-    data = load_obj('Farmington_River_data')
-    
-    # Change number of data points to illustrate effect
-    # of changing number of columns
-    ncol = 2
-    if ncol == 1:
-        sdev = data.sdev[0:11]
-        crmsd = data.crmsd[0:11]
-        ccoef = data.ccoef[0:11]
-        gageID = data.gageID[0:11]
-    elif ncol == 2:
-        sdev = data.sdev
-        crmsd = data.crmsd
-        ccoef = data.ccoef
-        gageID = data.gageID
-    else:
-        sdev = data.sdev
-        crmsd = data.crmsd
-        ccoef = data.ccoef
-        gageID = data.gageID
-        sdev = np.append(sdev,data.sdev[1:11])
-        crmsd = np.append(crmsd,data.crmsd[1:11])
-        ccoef = np.append(ccoef,data.ccoef[1:11])
-        gageID = gageID + data.gageID[1:11]
-    
-    # Specify labels for points in a cell array using gage ID.
-    label = gageID
-    
-    # Must set figure size here to prevent legend from being cut off
-    plt.figure(num=1, figsize=(8, 6))
-
-    
-    '''
-    Produce the Taylor diagram
-
-    Label the points and change the axis options for SDEV, CRMSD, and CCOEF.
-    Increase the upper limit for the SDEV axis and rotate the CRMSD contour 
-    labels (counter-clockwise from x-axis). Exchange color and line style
-    choices for SDEV, CRMSD, and CCOEFF variables to show effect. Increase
-    the line width of all lines. Suppress axes titles and add a legend.
-
-    For an exhaustive list of options to customize your diagram, 
-    please call the function at a Python command line:
-    >> taylor_diagram
-    '''    
-    sm.taylor_diagram(sdev,crmsd,ccoef, markerLabel = label, markerLabelColor = 'r', 
-                      markerLegend = 'on', markerColor = 'r',
-                      styleOBS = '-', colOBS = 'r', markerobs = 'o',
-                      markerSize = 6, tickRMS = [0.0, 1.0, 2.0, 3.0],
-                      tickRMSangle = 115, showlabelsRMS = 'on',
-                      titleRMS = 'on', titleOBS = 'Ref')
-
-    # Write plot to file if arguments say so
-    None if args.no_save else plt.savefig('taylor10.png')
-
-    # Show plot if arguments say so
-    None if args.no_show else plt.show()
-    plt.close()
+    # Write plot to file if arguments say so
+    None if args.no_save else plt.savefig('taylor10.png')
+
+    # Show plot if arguments say so
+    None if args.no_show else plt.show()
+    plt.close()

--- a/Examples/taylor_option_config.csv
+++ b/Examples/taylor_option_config.csv
@@ -1,0 +1,55 @@
+﻿KEY,VALUE,Notes
+alpha,1,blending of symbol face color (0.0 transparent through 1.0 opaque). (Default : 1.0)
+axismax,0,maximum for the radial contours
+checkstats,off,Check input statistics satisfy Taylor relationship (Default : 'off')
+cmap,jet,Choice of colormap. (Default : 'jet')
+cmap_vmin,None,minimum range of colormap (Default : None)
+cmap_vmax,None,maximum range of colormap (Default : None)
+cmap_marker,d,maximum range of colormap (Default : None)
+cmapzdata,,"data values to use for color mapping of markers, e.g. RMSD or BIAS. (Default empty)"
+colcor,"0, 0, 1",color for correlation coefficient labels (Default : blue)
+colscor,None,"if None, considers 'colcor' only"
+colobs,r,color for observation labels (Default : magenta)
+colrms,"0, .6, 0",color for RMS labels (Default : medium green)
+colstd,"0, 0, 0",color for STD labels (Default : black)
+colsstd,None,"if None, considers 'colstd' only"
+colframe,#000000,black
+colormap,on,on'/'off' switch to map color shading of markers to CMapZData values ('on') or min to max range of CMapZData values ('off'). (Default : 'on')
+labelrms,RMSD,RMS axis label (Default: 'RMSD')
+labelweight,bold,"weight of the x/y labels ('light', 'normal', 'bold', ...)"
+locationcolorbar,NorthOutside,"location for the colorbar, 'NorthOutside' or 'EastOutside'"
+markercolor,r,single color to use for all markers (Default: red)
+markercolors,None,"if None, considers 'markercolor' only"
+markerdisplayed,marker,markers to use for individual experiments
+markerlabel,,name of the experiment to use for marker
+markerlabelcolor,r,marker label color (Default : 'k')
+markerlegend,on,on'/'off' switch to display marker legend (Default 'off')
+markerobs,o,marker to use for x-axis indicating observed STD. A choice of 'none' will suppress appearance of marker. (Default 'none')
+markersize,6,marker size (Default 10)
+markersymbol,.,marker symbol (Default '.')
+titlecorshape,curved,
+overlay,off,'on'/'off' switch to overlay current statistics on Taylor diagram (Default 'off') Only markers will be displayed.
+rincrms,[0. 1. 2. 3.],axis tick increment for RMS values
+rincstd,,axis tick increment for STD values
+rmslabelformat,0,"string format for RMS contour labels, e.g. '0:.2f'. (Default '0', format as specified by str function)"
+showlabelscor,on,show correlation coefficient labels (Default: 'on')
+showlabelsrms,on,show RMS labels (Default: 'on')
+showlabelsstd,on,show STD labels (Default: 'on')
+stylecor,-.,line style for correlation coefficient grid lines (Default: dash-dot '-.')
+styleobs,-,line style for observation grid line. A choice of empty string '' will suppress appearance of the grid line (Default: '')
+stylerms,--,line style for RMS grid lines (Default: dash '--')
+stylestd,:,line style for STD grid lines (Default: dotted ':')
+tickrms,,RMS values to plot grid circles from observation point
+tickstd,,STD values to plot grid circles from origin
+tickrmsangle,115,tick RMS angle (Default: 135 degrees)
+titlecolorbar,,title for the colorbar
+titlecor,on,show correlation coefficient axis label (Default: 'on')
+titleobs,Ref,label for observation point (Default: '')
+titlerms,on,show RMS axis label (Default: 'on')
+titlermsdangle,160,show STD axis label (Default: 'on')
+titlestd,on,angle at which to display the 'RMSD' label for the RMS contours (Default: 160 degrees)
+widthcor,,linewidth for correlation coefficient grid lines (Default: .8)
+widthobs,,linewidth for observation grid line (Default: .8)
+widthrms,,linewidth for RMS grid lines (Default: .8)
+widthstd,,linewidth for STD grid lines (Default: .8)
+taylor_options_file,taylor_option_config.csv,filename for the options


### PR DESCRIPTION
Added a feature to the get_taylor_diagram_options file that allows the function to read a CSV file.

Here is a list of new functions that have been added:
`_read_options`: finds and reads the options from the CSV file

Here is a list of things that have been changed:
`Taylor10.py`: Moved all the keyword arguments to the CSV file so there would not be that many keyword arguments